### PR TITLE
パフォーマンス改善

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -127,9 +127,9 @@ export default {
     },
     goLoginPage () {
       if (this.$route.path === '/') {
-        this.$router.push({ path: '/login' })
+        this.$router.push({ name: 'Login' })
       } else {
-        this.$router.push({ path: '/login', query: { backuri: this.$router.currentRoute.path } })
+        this.$router.push({ name: 'Login', query: { backuri: this.$router.currentRoute.path } })
       }
     },
     reload () {

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,9 +64,11 @@
     </v-app-bar>
 
     <v-main>
-      <v-fade-transition>
-        <router-view/>
-      </v-fade-transition>
+      <keep-alive>
+        <v-fade-transition>
+          <router-view/>
+        </v-fade-transition>
+      </keep-alive>
     </v-main>
     <v-footer
       color="transparent"

--- a/src/components/modules/BreadCrumbs.vue
+++ b/src/components/modules/BreadCrumbs.vue
@@ -1,0 +1,36 @@
+<template functional>
+  <v-breadcrumbs :items="$options.generateItems(props)" class="pt-1 pl-2">
+    <template v-slot:divider>
+      <v-icon>mdi-chevron-right</v-icon>
+    </template>
+  </v-breadcrumbs>
+</template>
+
+<script>
+export default {
+  props: {
+    path: Array
+  },
+  generateItems (props) {
+    var crumbsItems = [
+      {
+        text: 'Top',
+        link: true,
+        exact: true,
+        disabled: false,
+        to: { name: 'TopPage' }
+      }
+    ]
+    props.path.forEach(elem => {
+      crumbsItems.push(
+        {
+          ...elem,
+          link: true,
+          exact: true
+        }
+      )
+    })
+    return crumbsItems
+  }
+}
+</script>

--- a/src/components/modules/DailyReports/DailyReportsCard.vue
+++ b/src/components/modules/DailyReports/DailyReportsCard.vue
@@ -1,23 +1,23 @@
 <template functional>
   <v-card>
     <v-card-subtitle class="pb-0">
-      {{ $options.dateFormatter(props.created_at) }}
+      {{ $options.dateFormatter(props.report_content_data.created_at) }}
     </v-card-subtitle>
     <v-card-title>
-      {{ `#${props.id} ${props.title}` }}
+      {{ `#${props.report_content_data.id} ${props.report_content_data.title}` }}
     </v-card-title>
     <v-card-text
       class="text--primary text-truncate d-inline-block"
       style="max-width: 180px"
     >
-      {{ $options.removeHtmlTag(props.body_text) }}
+      {{ $options.removeHtmlTag(props.report_content_data.body_text) }}
     </v-card-text>
     <v-card-actions>
       <v-btn
         text
         color="blue-grey lighten-1"
         link
-        :to="`/daily_reports/post/${props.id}`"
+        @click="$options.goToReportPage(props)"
       >
         {{ $options.translate('dailyReport.readMore') }}
       </v-btn>
@@ -26,14 +26,12 @@
 </template>
 
 <script>
+import { router } from '@/router'
 import i18next from 'i18next'
 export default {
   name: 'daily-reports-card',
   props: {
-    id: Number,
-    title: String,
-    body_text: String,
-    created_at: String
+    report_content_data: Object
   },
   translate (str) { // 関数型コンポーネントコンポーネントである関係上、$t関数が使えないので定義
     return i18next.t(str)
@@ -57,6 +55,18 @@ export default {
     } else {
       return txt
     }
+  },
+  goToReportPage (props) {
+    router.push(
+      {
+        name: 'DailyReportPage',
+        params: {
+          id: props.report_content_data.id,
+          report_content_data: props.report_content_data,
+          title: props.report_content_data.title
+        }
+      }
+    )
   }
 }
 </script>

--- a/src/components/modules/DailyReports/DailyReportsCard.vue
+++ b/src/components/modules/DailyReports/DailyReportsCard.vue
@@ -63,7 +63,7 @@ export default {
         params: {
           id: props.report_content_data.id,
           report_content_data: props.report_content_data,
-          title: props.report_content_data.title
+          title: `#${props.report_content_data.id} ${props.report_content_data.title}`
         }
       }
     )

--- a/src/components/modules/DailyReports/DailyReportsCard.vue
+++ b/src/components/modules/DailyReports/DailyReportsCard.vue
@@ -1,0 +1,62 @@
+<template functional>
+  <v-card>
+    <v-card-subtitle class="pb-0">
+      {{ $options.dateFormatter(props.created_at) }}
+    </v-card-subtitle>
+    <v-card-title>
+      {{ `#${props.id} ${props.title}` }}
+    </v-card-title>
+    <v-card-text
+      class="text--primary text-truncate d-inline-block"
+      style="max-width: 180px"
+    >
+      {{ $options.removeHtmlTag(props.body_text) }}
+    </v-card-text>
+    <v-card-actions>
+      <v-btn
+        text
+        color="blue-grey lighten-1"
+        link
+        :to="`/daily_reports/post/${props.id}`"
+      >
+        {{ $options.translate('dailyReport.readMore') }}
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+import i18next from 'i18next'
+export default {
+  name: 'daily-reports-card',
+  props: {
+    id: Number,
+    title: String,
+    body_text: String,
+    created_at: String
+  },
+  translate (str) { // 関数型コンポーネントコンポーネントである関係上、$t関数が使えないので定義
+    return i18next.t(str)
+  },
+  dateFormatter (date) {
+    var datetime = new Date(`${date}Z`)
+    var yearString = datetime.getFullYear()
+    var monthString = `0${datetime.getMonth() + 1}`.slice(-2) // 0埋め
+    var dateString = `0${datetime.getDate()}`.slice(-2)
+    var dayString = i18next.t(`commons.dayNameShort.${datetime.getDay()}`)
+    var hourString = `0${datetime.getHours()}`.slice(-2)
+    var minuteString = `0${datetime.getMinutes()}`.slice(-2)
+    var secondsString = `0${datetime.getSeconds()}`.slice(-2)
+    var formattedTime = `${yearString}/${monthString}/${dateString} (${dayString}) ${hourString}:${minuteString}:${secondsString}`
+
+    return formattedTime
+  },
+  removeHtmlTag (txt) {
+    if (txt != null && txt.match(/<("[^"]*"|'[^']*'|[^'">])*>/g)) {
+      return txt.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, '')
+    } else {
+      return txt
+    }
+  }
+}
+</script>

--- a/src/components/modules/Works/WorksCard.vue
+++ b/src/components/modules/Works/WorksCard.vue
@@ -2,11 +2,11 @@
   <v-card>
     <v-img
       class="white--text align-end"
-      :src="$options.workPictureURL(props.work_picture_url)"
+      :src="$options.workPictureURL(props.work_detail_data.work_picture_url)"
       :lazy-src="require('@/assets/NO_IMAGE_AVAILABLE.png')"
       gradient="to bottom, rgba(0,0,0,.2), rgba(0,0,0,.4)"
     >
-      <v-card-title>{{ props.work_name }}</v-card-title>
+      <v-card-title>{{ props.work_detail_data.name }}</v-card-title>
       <template v-slot:placeholder>
         <v-row
           class="fill-height ma-0"
@@ -22,7 +22,7 @@
     </v-img>
     <v-card-text>
       <div
-        v-html="props.top_page_outline"
+        v-html="props.work_detail_data.top_page_outline"
         class="text-body-1 text--primary"
         style="padding-top: 2px"
       />
@@ -31,7 +31,7 @@
       <v-btn
         text
         color="blue-grey lighten-1"
-        :to="`/my_work/detail/${props.endpoint_uri}`"
+        @click="$options.goToDetailPage(props)"
       >
         詳しい情報
       </v-btn>
@@ -40,13 +40,12 @@
 </template>
 
 <script>
+import { md } from '@/plugins/vue-markdown'
+import { router } from '@/router'
 export default {
   name: 'works-card',
   props: {
-    work_name: String,
-    work_picture_url: String,
-    top_page_outline: String,
-    endpoint_uri: String
+    work_detail_data: Object
   },
   workPictureURL (url) {
     if (url) {
@@ -54,6 +53,19 @@ export default {
     } else {
       return require('@/assets/NO_IMAGE_AVAILABLE.png')
     }
+  },
+  goToDetailPage (props) {
+    props.work_detail_data.description = md.render(props.work_detail_data.description)
+    router.push(
+      {
+        name: 'WorkDetailPage',
+        params: {
+          endpoint_uri: props.work_detail_data.endpoint_uri,
+          work_detail_data: props.work_detail_data,
+          title: props.work_detail_data.name
+        }
+      }
+    )
   }
 }
 </script>

--- a/src/components/modules/Works/WorksCard.vue
+++ b/src/components/modules/Works/WorksCard.vue
@@ -62,7 +62,7 @@ export default {
         params: {
           endpoint_uri: props.work_detail_data.endpoint_uri,
           work_detail_data: props.work_detail_data,
-          title: props.work_detail_data.name
+          title: `${props.work_detail_data.name} - My Works`
         }
       }
     )

--- a/src/components/modules/Works/WorksCard.vue
+++ b/src/components/modules/Works/WorksCard.vue
@@ -1,0 +1,59 @@
+<template functional>
+  <v-card>
+    <v-img
+      class="white--text align-end"
+      :src="$options.workPictureURL(props.work_picture_url)"
+      :lazy-src="require('@/assets/NO_IMAGE_AVAILABLE.png')"
+      gradient="to bottom, rgba(0,0,0,.2), rgba(0,0,0,.4)"
+    >
+      <v-card-title>{{ props.work_name }}</v-card-title>
+      <template v-slot:placeholder>
+        <v-row
+          class="fill-height ma-0"
+          align="center"
+          justify="center"
+        >
+          <v-progress-circular
+            indeterminate
+            color="grey darken-2"
+          ></v-progress-circular>
+        </v-row>
+      </template>
+    </v-img>
+    <v-card-text>
+      <div
+        v-html="props.top_page_outline"
+        class="text-body-1 text--primary"
+        style="padding-top: 2px"
+      />
+    </v-card-text>
+    <v-card-actions>
+      <v-btn
+        text
+        color="blue-grey lighten-1"
+        :to="`/my_work/detail/${props.endpoint_uri}`"
+      >
+        詳しい情報
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+export default {
+  name: 'works-card',
+  props: {
+    work_name: String,
+    work_picture_url: String,
+    top_page_outline: String,
+    endpoint_uri: String
+  },
+  workPictureURL (url) {
+    if (url) {
+      return url
+    } else {
+      return require('@/assets/NO_IMAGE_AVAILABLE.png')
+    }
+  }
+}
+</script>

--- a/src/components/pages/AboutMe.vue
+++ b/src/components/pages/AboutMe.vue
@@ -1,10 +1,9 @@
 <template>
   <v-container>
-    <v-breadcrumbs :items="crumbsItem" class="pt-1 pl-2">
-      <template v-slot:divider>
-        <v-icon>mdi-chevron-right</v-icon>
-      </template>
-    </v-breadcrumbs>
+    <BreadCrumbs
+      :path="pathList"
+    />
+
     <div class="bodyContent">
       <v-card
         class="pa-3"
@@ -79,21 +78,14 @@
 <script>
 export default {
   name: 'about-me',
+  components: {
+    BreadCrumbs: () => (import('@/components/modules/BreadCrumbs'))
+  },
   data () {
     return {
-      crumbsItem: [
-        {
-          text: 'Top',
-          link: true,
-          exact: true,
-          disabled: false,
-          to: { name: 'TopPage' }
-        },
+      pathList: [
         {
           text: 'About Me',
-          link: true,
-          exact: true,
-          disabled: true,
           to: { name: 'AboutMe' }
         }
       ]

--- a/src/components/pages/DailyReport/DailyReportPage.vue
+++ b/src/components/pages/DailyReport/DailyReportPage.vue
@@ -1,6 +1,6 @@
-<template>
+<template functional>
   <v-container style="height: calc(100% - 44px)">
-    <v-breadcrumbs :items="crumbsItem" class="pt-1 pl-2">
+    <v-breadcrumbs :items="$options.crumbsItem(props)" class="pt-1 pl-2">
       <template v-slot:divider>
         <v-icon>mdi-chevron-right</v-icon>
       </template>
@@ -18,20 +18,20 @@
         >
           <v-card-title class="pb-0 pb-sm-4">
             <p class="display-1">
-              {{ `#${$route.params['id']} ${reportContent.title}` }}
+              {{ `#${props.report_content_data.id} ${props.report_content_data.title}` }}
             </p>
           </v-card-title>
         </v-col>
         <v-col>
           <v-card-subtitle class="pt-0 pt-sm-4 ml-2 ml-sm-0">
-            {{ $t('dailyReport.createdAt') }}: {{ dateFormatter(reportContent.createdAt) }}
-            <div v-if="reportContent.updatedAt != reportContent.createdAt">{{ $t('dailyReport.updatedAt') }}: {{ dateFormatter(reportContent.updatedAt) }}</div>
+            {{ $options.translate('dailyReport.createdAt') }}: {{ $options.dateFormatter(props.report_content_data.created_at) }}
+            <div v-if="props.report_content_data.updated_at != props.report_content_data.created_at">{{ $options.translate('dailyReport.updatedAt') }}: {{ $options.dateFormatter(props.report_content_data.updated_at) }}</div>
           </v-card-subtitle>
         </v-col>
       </v-row>
       <v-divider/>
       <div
-        v-html="reportContent.bodyText"
+        v-html="props.report_content_data.body_text"
         class="text-body-1 mx-7 my-5 text-justify text-left"
       />
     </v-card>
@@ -42,64 +42,43 @@
 import i18next from 'i18next'
 export default {
   name: 'daily-report-page',
-  data () {
-    return {
-      reportContent: {
-        title: null,
-        bodyText: null,
-        createdAt: null,
-        updatedAt: null
+  props: {
+    report_content_data: Object
+  },
+  translate (str) { // 関数型コンポーネントコンポーネントである関係上、$t関数が使えないので定義
+    return i18next.t(str)
+  },
+  crumbsItem (props) {
+    return [
+      {
+        text: 'Top',
+        disabled: false,
+        to: '/'
       },
-      crumbsItem: [
-        {
-          text: 'Top',
-          disabled: false,
-          to: '/'
-        },
-        {
-          text: 'Daily Reports',
-          disabled: false,
-          to: '/daily_reports/posts'
-        },
-        {
-          text: null,
-          disabled: true,
-          to: `/daily_reports/post/${this.$route.params['id']}`
-        }
-      ]
-    }
+      {
+        text: 'Daily Reports',
+        disabled: false,
+        to: '/daily_reports/posts'
+      },
+      {
+        text: props.report_content_data.title,
+        disabled: true,
+        to: `/daily_reports/post/${props.report_content_data.id}`
+      }
+    ]
   },
-  methods: {
-    async fetchPost () {
-      await this.$axios
-        .get(`/v1/post/${this.$route.params['id']}`)
-        .then(response => {
-          this.$set(this.reportContent, 'title', response.data.title)
-          this.$set(this.reportContent, 'bodyText', response.data.body_text)
-          this.$set(this.reportContent, 'createdAt', response.data.created_at)
-          this.$set(this.reportContent, 'updatedAt', response.data.updated_at)
+  dateFormatter (date) {
+    var datetime = new Date(`${date}Z`)
+    var yearString = datetime.getFullYear()
+    var monthString = `0${datetime.getMonth() + 1}`.slice(-2) // 0埋め
+    var dateString = `0${datetime.getDate()}`.slice(-2)
+    var dayString = i18next.t(`commons.dayNameShort.${datetime.getDay()}`)
+    var hourString = `0${datetime.getHours()}`.slice(-2)
+    var minuteString = `0${datetime.getMinutes()}`.slice(-2)
+    var secondsString = `0${datetime.getSeconds()}`.slice(-2)
+    var formattedTime = `${yearString}/${monthString}/${dateString} (${dayString}) ${hourString}:${minuteString}:${secondsString}`
 
-          this.$set(this.crumbsItem[2], 'text', `#${this.$route.params['id']} ${response.data.title}`)
-        })
-    },
-    dateFormatter (date) {
-      var datetime = new Date(`${date}Z`)
-      var yearString = datetime.getFullYear()
-      var monthString = `0${datetime.getMonth() + 1}`.slice(-2) // 0埋め
-      var dateString = `0${datetime.getDate()}`.slice(-2)
-      var dayString = i18next.t(`commons.dayNameShort.${datetime.getDay()}`)
-      var hourString = `0${datetime.getHours()}`.slice(-2)
-      var minuteString = `0${datetime.getMinutes()}`.slice(-2)
-      var secondsString = `0${datetime.getSeconds()}`.slice(-2)
-      var formattedTime = `${yearString}/${monthString}/${dateString} (${dayString}) ${hourString}:${minuteString}:${secondsString}`
-
-      return formattedTime
-    }
-  },
-  created () {
-    this.fetchPost()
-  },
-  mounted () {
+    return formattedTime
   }
 }
 </script>

--- a/src/components/pages/DailyReport/DailyReportPage.vue
+++ b/src/components/pages/DailyReport/DailyReportPage.vue
@@ -65,14 +65,14 @@ export default {
         to: { name: 'DailyReportsList' }
       },
       {
-        text: null,
+        text: `#${props.report_content_data.id} ${props.report_content_data.title}`,
         link: true,
         exact: true,
         disabled: true,
         to: {
           name: 'DailyReportPage',
           params: {
-            id: this.$route.params['id']
+            id: props.report_content_data.id
           }
         }
       }

--- a/src/components/pages/DailyReport/DailyReportsList.vue
+++ b/src/components/pages/DailyReport/DailyReportsList.vue
@@ -55,10 +55,7 @@
             :cols="(12 / itemsPerRow)"
           >
             <DailyReportsCard
-              :id="post.id"
-              :title="post.title"
-              :body_text="post.body_text"
-              :created_at="post.created_at"
+              :report_content_data="post"
             />
           </v-col>
         </v-row>

--- a/src/components/pages/DailyReport/DailyReportsList.vue
+++ b/src/components/pages/DailyReport/DailyReportsList.vue
@@ -1,10 +1,11 @@
 <template>
   <component :is="conditionalTag">
-    <v-breadcrumbs v-if="!isTopPage" :items="crumbsItem" class="pt-1 pl-2">
-      <template v-slot:divider>
-        <v-icon>mdi-chevron-right</v-icon>
-      </template>
-    </v-breadcrumbs>
+    <template v-if="!isTopPage">
+      <BreadCrumbs
+        :path="pagePath"
+      />
+    </template>
+
     <v-data-iterator
       :class="{'pa-0': isTopPage && reportPosts.length != 0, 'pl-8': reportPosts.length == 0, 'py-5': reportPosts.length == 0}"
       :items="reportPosts"
@@ -110,7 +111,8 @@ import DailyReportsCard from '@/components/modules/DailyReports/DailyReportsCard
 export default {
   name: 'daily-reports-list',
   components: {
-    DailyReportsCard
+    DailyReportsCard,
+    BreadCrumbs: () => (import('@/components/modules/BreadCrumbs'))
   },
   props: ['isTopPage'],
   data () {
@@ -122,19 +124,9 @@ export default {
       page: 1,
       sortBy: 'id',
       sortDesc: true,
-      crumbsItem: [
-        {
-          text: 'Top',
-          link: true,
-          exact: true,
-          disabled: false,
-          to: { name: 'TopPage' }
-        },
+      pagePath: [
         {
           text: 'Daily Reports',
-          link: true,
-          exact: true,
-          disabled: true,
           to: { name: 'DailyReportsList' }
         }
       ],

--- a/src/components/pages/DailyReport/DailyReportsList.vue
+++ b/src/components/pages/DailyReport/DailyReportsList.vue
@@ -54,30 +54,12 @@
             :key="post.uuid"
             :cols="(12 / itemsPerRow)"
           >
-            <v-card>
-              <v-card-subtitle class="pb-0">
-                {{ dateFormatter(post.created_at) }}
-              </v-card-subtitle>
-              <v-card-title>
-                {{ `#${post.id} ${post.title}` }}
-              </v-card-title>
-              <v-card-text
-               class="text--primary text-truncate d-inline-block"
-               style="max-width: 180px"
-              >
-                {{ removeHtmlTag(post.body_text) }}
-              </v-card-text>
-              <v-card-actions>
-                <v-btn
-                  text
-                  color="blue-grey lighten-1"
-                  link
-                  :to="`/daily_reports/post/${post.id}`"
-                >
-                  {{ $t('dailyReport.readMore') }}
-                </v-btn>
-              </v-card-actions>
-            </v-card>
+            <DailyReportsCard
+              :id="post.id"
+              :title="post.title"
+              :body_text="post.body_text"
+              :created_at="post.created_at"
+            />
           </v-col>
         </v-row>
       </template>
@@ -127,9 +109,12 @@
 </template>
 
 <script>
-import i18next from 'i18next'
+import DailyReportsCard from '@/components/modules/DailyReports/DailyReportsCard'
 export default {
   name: 'daily-reports-list',
+  components: {
+    DailyReportsCard
+  },
   props: ['isTopPage'],
   data () {
     return {
@@ -165,26 +150,6 @@ export default {
         .catch(_ => {
           this.reportPosts = []
         })
-    },
-    dateFormatter (date) {
-      var datetime = new Date(`${date}Z`)
-      var yearString = datetime.getFullYear()
-      var monthString = `0${datetime.getMonth() + 1}`.slice(-2) // 0埋め
-      var dateString = `0${datetime.getDate()}`.slice(-2)
-      var dayString = i18next.t(`commons.dayNameShort.${datetime.getDay()}`)
-      var hourString = `0${datetime.getHours()}`.slice(-2)
-      var minuteString = `0${datetime.getMinutes()}`.slice(-2)
-      var secondsString = `0${datetime.getSeconds()}`.slice(-2)
-      var formattedTime = `${yearString}/${monthString}/${dateString} (${dayString}) ${hourString}:${minuteString}:${secondsString}`
-
-      return formattedTime
-    },
-    removeHtmlTag (txt) {
-      if (txt != null && txt.match(/<("[^"]*"|'[^']*'|[^'">])*>/g)) {
-        return txt.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, '')
-      } else {
-        return txt
-      }
     },
     nextPage () {
       if (this.page + 1 <= this.numberOfPages) this.page += 1

--- a/src/components/pages/DailyReport/EditPost.vue
+++ b/src/components/pages/DailyReport/EditPost.vue
@@ -190,7 +190,7 @@ export default {
         })
         .catch((error) => {
           if (error.response.data.message === 'Missing cookie "access_token_cookie"') {
-            this.$router.push({path: '/login', query: {backuri: this.$route.fullPath}})
+            this.$router.push({name: 'Login', query: {backuri: this.$route.fullPath}})
           }
           this.deleteProgress = false
         })

--- a/src/components/pages/Works/WorkDetailPage.vue
+++ b/src/components/pages/Works/WorkDetailPage.vue
@@ -1,6 +1,6 @@
-<template>
+<template functional>
   <v-container style="height: calc(100% - 44px)">
-    <v-breadcrumbs :items="crumbsItem" class="pt-1 pl-2">
+    <v-breadcrumbs :items="$options.crumbsItem(props)" class="pt-1 pl-2">
       <template v-slot:divider>
         <v-icon>mdi-chevron-right</v-icon>
       </template>
@@ -12,22 +12,22 @@
     >
       <v-card-title class="pl-1 py-3 pl-sm-4 py-sm-4">
         <p class="display-1">
-          {{ work_detail_data.name }}
+          {{ props.work_detail_data.name }}
         </p>
       </v-card-title>
-      <template v-if="work_detail_data.work_url">
+      <template v-if="props.work_detail_data.work_url">
         <v-card-subtitle>
           <div>
-            リンク: <a :href="work_detail_data.work_url" ref="noopener noreferrer" target="_blank">{{ work_detail_data.work_url}}</a>
+            リンク: <a :href="props.work_detail_data.work_url" ref="noopener noreferrer" target="_blank">{{ props.work_detail_data.work_url}}</a>
           </div>
         </v-card-subtitle>
       </template>
 
       <v-row justify="center">
         <v-col cols="9">
-          <template v-if="work_detail_data.work_picture_url">
+          <template v-if="props.work_detail_data.work_picture_url">
             <v-img
-              :src="work_detail_data.work_picture_url"
+              :src="props.work_detail_data.work_picture_url"
               :lazy-src="require('@/assets/NO_IMAGE_AVAILABLE.png')"
               class="grey lighten-2"
             >
@@ -50,7 +50,7 @@
       </v-row>
 
       <div
-        v-html="work_detail_data.description"
+        v-html="props.work_detail_data.description"
         class="pt-6 mx-3 mx-sm-5"
       />
     </v-card>
@@ -60,27 +60,27 @@
 <script>
 export default {
   name: 'works-detail-page',
-  props: ['work_detail_data', 'crumbs_text', 'uri_props'],
-  data () {
-    return {
-      crumbsItem: [
-        {
-          text: 'Top',
-          disabled: false,
-          to: '/'
-        },
-        {
-          text: 'My Works',
-          disabled: false,
-          to: '/my_works'
-        },
-        {
-          text: this.crumbs_text,
-          disabled: true,
-          to: `/daily_reports/post/${this.$route.params['endpoint_uri']}`
-        }
-      ]
-    }
+  props: {
+    work_detail_data: Object
+  },
+  crumbsItem (props) {
+    return [
+      {
+        text: 'Top',
+        disabled: false,
+        to: '/'
+      },
+      {
+        text: 'My Works',
+        disabled: false,
+        to: '/my_works'
+      },
+      {
+        text: props.work_detail_data.name,
+        disabled: true,
+        to: `/daily_reports/post/${props.work_detail_data.endpoint_uri}`
+      }
+    ]
   }
 }
 </script>

--- a/src/components/pages/Works/WorkDetailPage.vue
+++ b/src/components/pages/Works/WorkDetailPage.vue
@@ -12,22 +12,22 @@
     >
       <v-card-title class="pl-1 py-3 pl-sm-4 py-sm-4">
         <p class="display-1">
-          {{ workDetailData.name }}
+          {{ work_detail_data.name }}
         </p>
       </v-card-title>
-      <template v-if="workDetailData.workURL">
+      <template v-if="work_detail_data.work_url">
         <v-card-subtitle>
           <div>
-            リンク: <a :href="workDetailData.workURL" ref="noopener noreferrer" target="_blank">{{ workDetailData.workURL}}</a>
+            リンク: <a :href="work_detail_data.work_url" ref="noopener noreferrer" target="_blank">{{ work_detail_data.work_url}}</a>
           </div>
         </v-card-subtitle>
       </template>
 
       <v-row justify="center">
         <v-col cols="9">
-          <template v-if="workDetailData.workPictureURL">
+          <template v-if="work_detail_data.work_picture_url">
             <v-img
-              :src="workDetailData.workPictureURL"
+              :src="work_detail_data.work_picture_url"
               :lazy-src="require('@/assets/NO_IMAGE_AVAILABLE.png')"
               class="grey lighten-2"
             >
@@ -50,7 +50,7 @@
       </v-row>
 
       <div
-        v-html="workDetailData.description"
+        v-html="work_detail_data.description"
         class="pt-6 mx-3 mx-sm-5"
       />
     </v-card>
@@ -60,14 +60,9 @@
 <script>
 export default {
   name: 'works-detail-page',
+  props: ['work_detail_data', 'crumbs_text', 'uri_props'],
   data () {
     return {
-      workDetailData: {
-        name: null,
-        description: null,
-        workURL: null,
-        workPictureURL: null
-      },
       crumbsItem: [
         {
           text: 'Top',
@@ -80,29 +75,12 @@ export default {
           to: '/my_works'
         },
         {
-          text: null,
+          text: this.crumbs_text,
           disabled: true,
           to: `/daily_reports/post/${this.$route.params['endpoint_uri']}`
         }
       ]
     }
-  },
-  methods: {
-    async fetchWorkDetail () {
-      await this.$axios
-        .get(`/v1/my_work/${this.$route.params['endpoint_uri']}`)
-        .then((response) => {
-          this.$set(this.workDetailData, 'name', response.data.name)
-          this.$set(this.workDetailData, 'description', this.$md.render(response.data.description))
-          this.$set(this.workDetailData, 'workURL', response.data.work_url)
-          this.$set(this.workDetailData, 'workPictureURL', response.data.work_picture_url)
-
-          this.$set(this.crumbsItem[2], 'text', response.data.name)
-        })
-    }
-  },
-  created () {
-    this.fetchWorkDetail()
   }
 }
 </script>

--- a/src/components/pages/Works/WorkDetailPage.vue
+++ b/src/components/pages/Works/WorkDetailPage.vue
@@ -80,14 +80,14 @@ export default {
         to: { name: 'WorksList' }
       },
       {
-        text: null,
+        text: props.work_detail_data.name,
         link: true,
         exact: true,
         disabled: true,
         to: {
-          name: 'WorksDetailPage',
+          name: 'WorkDetailPage',
           params: {
-            endpoint_uri: this.$route.params['endpoint_uri']
+            endpoint_uri: props.work_detail_data.endpoint_uri
           }
         }
       }

--- a/src/components/pages/Works/WorksList.vue
+++ b/src/components/pages/Works/WorksList.vue
@@ -56,10 +56,7 @@
             :cols="cardsCols"
           >
             <WorksCard
-              :work_name="work.name"
-              :work_picture_url="work.work_picture_url"
-              :top_page_outline="work.top_page_outline"
-              :endpoint_uri="work.endpoint_uri"
+              :work_detail_data="work"
             />
           </v-col>
         </v-row>

--- a/src/components/pages/Works/WorksList.vue
+++ b/src/components/pages/Works/WorksList.vue
@@ -1,10 +1,10 @@
 <template>
   <component :is="conditionalTag">
-    <v-breadcrumbs v-if="!isTopPage" :items="crumbsItem" class="pt-1 pl-2">
-      <template v-slot:divider>
-        <v-icon>mdi-chevron-right</v-icon>
-      </template>
-    </v-breadcrumbs>
+    <template v-if="!isTopPage">
+      <BreadCrumbs
+        :path="pathList"
+      />
+    </template>
 
     <v-data-iterator
       :class="{'pa-0': isTopPage && allWorksData.length != 0, 'pl-8': allWorksData.length == 0, 'py-5': allWorksData.length == 0}"
@@ -111,7 +111,8 @@ export default {
   name: 'works-list',
   props: ['isTopPage'],
   components: {
-    WorksCard
+    WorksCard,
+    BreadCrumbs: () => (import('@/components/modules/BreadCrumbs'))
   },
   data () {
     return {
@@ -121,19 +122,9 @@ export default {
       page: 1,
       sortBy: 'id',
       sortDesc: true,
-      crumbsItem: [
-        {
-          text: 'Top',
-          link: true,
-          exact: true,
-          disabled: false,
-          to: { name: 'TopPage' }
-        },
+      pathList: [
         {
           text: 'My Works',
-          link: true,
-          exact: true,
-          disabled: true,
           to: { name: 'WorksList' }
         }
       ],

--- a/src/components/pages/Works/WorksList.vue
+++ b/src/components/pages/Works/WorksList.vue
@@ -55,44 +55,12 @@
             :key="work.uuid"
             :cols="cardsCols"
           >
-            <v-card>
-              <v-img
-                class="white--text align-end"
-                :src="workPictureURL(work.work_picture_url)"
-                :lazy-src="require('@/assets/NO_IMAGE_AVAILABLE.png')"
-                gradient="to bottom, rgba(0,0,0,.2), rgba(0,0,0,.4)"
-              >
-                <v-card-title>{{ work.name }}</v-card-title>
-                <template v-slot:placeholder>
-                  <v-row
-                    class="fill-height ma-0"
-                    align="center"
-                    justify="center"
-                  >
-                    <v-progress-circular
-                      indeterminate
-                      color="grey darken-2"
-                    ></v-progress-circular>
-                  </v-row>
-                </template>
-              </v-img>
-              <v-card-text>
-                <div
-                  v-html="work.top_page_outline"
-                  class="text-body-1 text--primary"
-                  style="padding-top: 2px"
-                />
-              </v-card-text>
-              <v-card-actions>
-                <v-btn
-                  text
-                  color="blue-grey lighten-1"
-                  :to="`/my_work/detail/${work.endpoint_uri}`"
-                >
-                  詳しい情報
-                </v-btn>
-              </v-card-actions>
-            </v-card>
+            <WorksCard
+              :work_name="work.name"
+              :work_picture_url="work.work_picture_url"
+              :top_page_outline="work.top_page_outline"
+              :endpoint_uri="work.endpoint_uri"
+            />
           </v-col>
         </v-row>
       </template>
@@ -141,9 +109,13 @@
 </template>
 
 <script>
+import WorksCard from '@/components/modules/Works/WorksCard'
 export default {
   name: 'works-list',
   props: ['isTopPage'],
+  components: {
+    WorksCard
+  },
   data () {
     return {
       showSearch: false,
@@ -178,13 +150,6 @@ export default {
         .catch(() => {
           this.allWorksData = []
         })
-    },
-    workPictureURL (url) {
-      if (url) {
-        return url
-      } else {
-        return require('@/assets/NO_IMAGE_AVAILABLE.png')
-      }
     },
     nextPage () {
       if (this.page + 1 <= this.numberOfPages) this.page += 1

--- a/src/plugins/custom-axios.js
+++ b/src/plugins/custom-axios.js
@@ -1,9 +1,11 @@
 import axios from 'axios'
 
+export const api = axios.create({
+  baseURL: process.env.VUE_APP_API_ENDPOINT
+})
+
 export default {
   install (vue) {
-    vue.prototype.$axios = axios.create({
-      baseURL: process.env.VUE_APP_API_ENDPOINT
-    })
+    vue.prototype.$axios = api
   }
 }

--- a/src/plugins/vue-markdown/index.js
+++ b/src/plugins/vue-markdown/index.js
@@ -3,7 +3,7 @@ const mdOptions = {
   html: true,
   linkify: true
 }
-var md = require('markdown-it')(mdOptions)
+export var md = require('markdown-it')(mdOptions)
 const checkboxOptions = {
   divWrap: true
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,8 +3,6 @@ import Router from 'vue-router'
 import { api } from '@/plugins/custom-axios'
 import { md } from '@/plugins/vue-markdown'
 import TopPage from '@/components/pages/TopPage'
-import WorksList from '@/components/pages/Works/WorksList'
-import DailyReportsList from '@/components/pages/DailyReport/DailyReportsList'
 
 Vue.use(Router)
 
@@ -19,7 +17,7 @@ export const router = new Router({
     {
       path: '/my_works',
       name: 'WorksList',
-      component: WorksList,
+      component: () => import('@/components/pages/Works/WorksList'),
       meta: {
         title: 'My Works'
       }
@@ -31,16 +29,14 @@ export const router = new Router({
       props: true,
       beforeEnter: (to, from, next) => {
         if (!to.params.work_detail_data) {
-          api
-            .get(`/v1/my_work/${to.params.endpoint_uri}`)
-            .then((response) => {
-              to.params.work_detail_data = response.data
-              to.params.work_detail_data.description = md.render(
-                response.data.description
-              )
-              to.meta.title = `${response.data.name} - My Works`
-              next()
-            })
+          api.get(`/v1/my_work/${to.params.endpoint_uri}`).then((response) => {
+            to.params.work_detail_data = response.data
+            to.params.work_detail_data.description = md.render(
+              response.data.description
+            )
+            to.meta.title = `${response.data.name} - My Works`
+            next()
+          })
         } else {
           to.meta.title = to.params.title
           next()
@@ -50,7 +46,7 @@ export const router = new Router({
     {
       path: '/daily_reports/posts',
       name: 'DailyReportsList',
-      component: DailyReportsList,
+      component: () => import('@/components/pages/DailyReport/DailyReportsList'),
       meta: {
         title: 'Daily Reports'
       }
@@ -62,13 +58,11 @@ export const router = new Router({
       props: true,
       beforeEnter: (to, from, next) => {
         if (!to.params.report_content_data) {
-          api
-            .get(`/v1/post/${to.params.id}`)
-            .then((response) => {
-              to.params.report_content_data = response.data
-              to.meta.title = `#${to.params.id} ${response.data.title}`
-              next()
-            })
+          api.get(`/v1/post/${to.params.id}`).then((response) => {
+            to.params.report_content_data = response.data
+            to.meta.title = `#${to.params.id} ${response.data.title}`
+            next()
+          })
         } else {
           to.meta.title = to.params.title
           next()

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -61,13 +61,20 @@ export const router = new Router({
       path: '/daily_reports/post/:id',
       name: 'DailyReportPage',
       component: () => import('@/components/pages/DailyReport/DailyReportPage'),
+      props: true,
       beforeEnter: (to, from, next) => {
-        axios
-          .get(`${process.env.VUE_APP_API_ENDPOINT}/v1/post/${to.params.id}`)
-          .then((response) => {
-            to.meta.title = `#${to.params.id} ${response.data.title}`
-            next()
-          })
+        if (!to.params.report_content_data) {
+          axios
+            .get(`${process.env.VUE_APP_API_ENDPOINT}/v1/post/${to.params.id}`)
+            .then((response) => {
+              to.params.report_content_data = response.data
+              to.meta.title = `#${to.params.id} ${response.data.title}`
+              next()
+            })
+        } else {
+          to.meta.title = to.params.title
+          next()
+        }
       }
     },
     {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,16 +30,23 @@ export const router = new Router({
       component: () => import('@/components/pages/Works/WorkDetailPage'),
       props: true,
       beforeEnter: (to, from, next) => {
-        axios
-          .get(`${process.env.VUE_APP_API_ENDPOINT}/v1/my_work/${to.params.endpoint_uri}`)
-          .then((response) => {
-            to.params.work_detail_data = response.data
-            to.params.work_detail_data.description = md.render(response.data.description)
-            to.params.crumbs_text = response.data.name
-            to.params.uri_props = to.params.endpoint_uri
-            to.meta.title = `${response.data.name} - My Works`
-            next()
-          })
+        if (!to.params.work_detail_data) {
+          axios
+            .get(
+              `${process.env.VUE_APP_API_ENDPOINT}/v1/my_work/${to.params.endpoint_uri}`
+            )
+            .then((response) => {
+              to.params.work_detail_data = response.data
+              to.params.work_detail_data.description = md.render(
+                response.data.description
+              )
+              to.meta.title = `${response.data.name} - My Works`
+              next()
+            })
+        } else {
+          to.meta.title = to.params.title
+          next()
+        }
       }
     },
     {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,7 +33,7 @@ export const router = new Router({
         if (!to.params.work_detail_data) {
           api
             .get(
-              `${process.env.VUE_APP_API_ENDPOINT}/v1/my_work/${to.params.endpoint_uri}`
+              `/v1/my_work/${to.params.endpoint_uri}`
             )
             .then((response) => {
               to.params.work_detail_data = response.data
@@ -65,7 +65,7 @@ export const router = new Router({
       beforeEnter: (to, from, next) => {
         if (!to.params.report_content_data) {
           api
-            .get(`${process.env.VUE_APP_API_ENDPOINT}/v1/post/${to.params.id}`)
+            .get(`/v1/post/${to.params.id}`)
             .then((response) => {
               to.params.report_content_data = response.data
               to.meta.title = `#${to.params.id} ${response.data.title}`

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import axios from 'axios'
+import { md } from '@/plugins/vue-markdown'
 import TopPage from '@/components/pages/TopPage'
 import WorksList from '@/components/pages/Works/WorksList'
 import DailyReportsList from '@/components/pages/DailyReport/DailyReportsList'
@@ -27,10 +28,15 @@ export const router = new Router({
       path: '/my_work/detail/:endpoint_uri',
       name: 'WorkDetailPage',
       component: () => import('@/components/pages/Works/WorkDetailPage'),
+      props: true,
       beforeEnter: (to, from, next) => {
         axios
           .get(`${process.env.VUE_APP_API_ENDPOINT}/v1/my_work/${to.params.endpoint_uri}`)
           .then((response) => {
+            to.params.work_detail_data = response.data
+            to.params.work_detail_data.description = md.render(response.data.description)
+            to.params.crumbs_text = response.data.name
+            to.params.uri_props = to.params.endpoint_uri
             to.meta.title = `${response.data.name} - My Works`
             next()
           })

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,9 +32,7 @@ export const router = new Router({
       beforeEnter: (to, from, next) => {
         if (!to.params.work_detail_data) {
           api
-            .get(
-              `/v1/my_work/${to.params.endpoint_uri}`
-            )
+            .get(`/v1/my_work/${to.params.endpoint_uri}`)
             .then((response) => {
               to.params.work_detail_data = response.data
               to.params.work_detail_data.description = md.render(


### PR DESCRIPTION
- # やったこと
  - 成果物データ取得・日報データ取得のAPIを叩く回数を1回で済むように
  - `keep-alive`追加
  - ルーター内で動的インポート
  - 日報一覧のカード・成果物一覧のカードを関数型コンポーネントに分離・置換
  - カレントパスを表示しているbreadcrumbsを関数型コンポーネントに分離
  - 認証済みかどうかを確認するbeforeEach内の処理方法を見直し